### PR TITLE
[hotfix] 상세페이지에서 상품, 브랜드 좋아요 누르면 이동할수 있는 toast 추가

### DIFF
--- a/app/(user)/saved/page.tsx
+++ b/app/(user)/saved/page.tsx
@@ -62,6 +62,7 @@ const SavedPage = () => {
         .then((res) => {
           if (res.status === 200) {
             initLikeBrand();
+            alert('삭제완료!');
           }
         })
         .catch((error) => {
@@ -95,6 +96,7 @@ const SavedPage = () => {
         .then((res) => {
           if (res.status === 200) {
             initSave();
+            alert('삭제완료!');
           }
         })
         .catch((error) => {
@@ -112,7 +114,6 @@ const SavedPage = () => {
 
       if (likeCheck) {
         handleDeleteLike(productId);
-        alert('제거완료');
       } else {
         addLike(productId)
           .then((res) => {

--- a/app/(user)/saved/page.tsx
+++ b/app/(user)/saved/page.tsx
@@ -10,6 +10,13 @@ import ProductSave from '@/components/saved/ProductSave';
 import BrandSave from '@/components/saved/BrandSave';
 import RecentlySave from '@/components/saved/RecentlySave';
 import { TABS } from '@/constraint/saved';
+import { useSearchParams } from 'next/navigation';
+
+interface SAVED_TABS {
+  product: string;
+  brand: string;
+  recent: string;
+}
 
 const SavedPage = () => {
   const { addLike, deleteLike, getLikes, deleteBrandLike, getBrandLikes } = likeService;
@@ -18,6 +25,8 @@ const SavedPage = () => {
   const [likeList, setLikeList] = useState<ILikeList[]>([]);
   const [brandLikeList, setBrandLikeList] = useState<IBrandLikeList[]>([]);
   const [recentProducts, setRecentProducts] = useState<IRecentProduct[]>([]);
+
+  const searchParams = useSearchParams();
 
   const handleGetRecentlyProduct = useCallback(
     (ids: string[]) => {
@@ -148,7 +157,13 @@ const SavedPage = () => {
     handleGetRecentlyProduct(storage);
   }, [handleGetRecentlyProduct]);
 
-  useEffect(() => {}, []);
+  useEffect(() => {
+    const tabs = { product: 0, brand: 1, recent: 2 };
+
+    const params = (searchParams.get('tab') as keyof SAVED_TABS) ?? 'product';
+
+    setSelectTab(tabs[params]);
+  }, [searchParams]);
 
   return (
     <section>

--- a/app/(user)/saved/page.tsx
+++ b/app/(user)/saved/page.tsx
@@ -90,9 +90,7 @@ const SavedPage = () => {
 
   const handleDeleteLike = useCallback(
     (id: number) => {
-      const deleteId = likeList?.find((item) => item?.product?.id === id)?.id ?? 0;
-
-      deleteLike(deleteId)
+      deleteLike(id)
         .then((res) => {
           if (res.status === 200) {
             initSave();
@@ -103,7 +101,7 @@ const SavedPage = () => {
           console.log('error', error.message);
         });
     },
-    [deleteLike, initSave, likeList]
+    [deleteLike, initSave]
   );
 
   const handleLikeAdd = useCallback(

--- a/app/api/brand-likes/route.ts
+++ b/app/api/brand-likes/route.ts
@@ -28,11 +28,17 @@ export async function POST(request: NextRequest) {
 }
 
 export async function DELETE(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user?.id) {
+    return Response.json({ error: '로그인이 필요합니다.' }, { status: 401 });
+  }
+
   try {
     const body = await request.json();
 
     const brandLikesRepository = new PrBrandLikesRepository();
-    const brandLikes = new DeleteBrandLikesUseCase(brandLikesRepository).delete(body.id);
+    const brandLikes = new DeleteBrandLikesUseCase(brandLikesRepository).delete(body.id, session?.user?.id);
 
     return NextResponse.json({ result: brandLikes, status: 200 });
   } catch (error) {

--- a/app/api/likes/route.ts
+++ b/app/api/likes/route.ts
@@ -28,11 +28,17 @@ export async function POST(request: NextRequest) {
 }
 
 export async function DELETE(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user?.id) {
+    return Response.json({ error: '로그인이 필요합니다.' }, { status: 401 });
+  }
+
   try {
     const body = await request.json();
 
     const likeRepository = new PrLikesRepository();
-    const likes = new DeleteLikesUseCase(likeRepository).delete(body.id);
+    const likes = new DeleteLikesUseCase(likeRepository).delete(body.id, session?.user?.id);
 
     return NextResponse.json({ result: likes, status: 200 });
   } catch (error) {

--- a/backend/brand-likes/applications/usecases/DeleteBrandLikesUseCase.ts
+++ b/backend/brand-likes/applications/usecases/DeleteBrandLikesUseCase.ts
@@ -7,9 +7,9 @@ export class DeleteBrandLikesUseCase {
     this.repository = repository;
   }
 
-  async delete(id: number): Promise<number> {
+  async delete(brandId: number, userId: string): Promise<number> {
     try {
-      const result = await this.repository.delete(id);
+      const result = await this.repository.delete(brandId, userId);
 
       return result;
     } catch {

--- a/backend/brand-likes/domains/entities/BrandLikes.ts
+++ b/backend/brand-likes/domains/entities/BrandLikes.ts
@@ -1,5 +1,4 @@
 export interface BrandLike {
-  id: number;
   brand: Brand;
 }
 

--- a/backend/brand-likes/domains/repositories/BrandLikesRepository.ts
+++ b/backend/brand-likes/domains/repositories/BrandLikesRepository.ts
@@ -2,6 +2,6 @@ import { BrandLike } from '../entities/BrandLikes';
 
 export interface BrandLikesRepository {
   insert(userId: string, brandId: number): Promise<number>;
-  delete(id: number): Promise<number>;
+  delete(id: number, userId: string): Promise<number>;
   findById(userId: string): Promise<BrandLike[]>;
 }

--- a/backend/brand-likes/repositories/PrBrandLikesRepository.ts
+++ b/backend/brand-likes/repositories/PrBrandLikesRepository.ts
@@ -13,24 +13,27 @@ export class PrBrandLikesRepository implements BrandLikesRepository {
         },
       });
 
-      return result.id;
+      return result.brandId;
     } catch {
       throw new Error('=====BRANDS_INSERT_ERROR=====');
     }
   }
 
-  async delete(id: number): Promise<number> {
+  async delete(brandId: number, userId: string): Promise<number> {
+    console.log('========================================');
+    console.log('PrBrandLikesRepository', brandId, '/', userId);
+    console.log('========================================');
     try {
       const result = await prisma.brandLike.delete({
         where: {
-          id: id,
+          userId_brandId: { brandId, userId },
         },
         select: {
-          id: true,
+          brandId: true,
         },
       });
 
-      return result.id;
+      return result.brandId;
     } catch {
       throw new Error('=====BRAND_LIKE_INSERT_ERROR=====');
     }
@@ -43,7 +46,6 @@ export class PrBrandLikesRepository implements BrandLikesRepository {
           userId: userId,
         },
         select: {
-          id: true,
           brand: {
             select: {
               engName: true,

--- a/backend/likes/applications/usecases/DeleteLikesUseCase.ts
+++ b/backend/likes/applications/usecases/DeleteLikesUseCase.ts
@@ -7,9 +7,9 @@ export class DeleteLikesUseCase {
     this.repository = repository;
   }
 
-  async delete(id: number): Promise<number> {
+  async delete(id: number, userId: string): Promise<number> {
     try {
-      const result = await this.repository.delete(id);
+      const result = await this.repository.delete(id, userId);
 
       return result;
     } catch {

--- a/backend/likes/domains/entities/Likes.ts
+++ b/backend/likes/domains/entities/Likes.ts
@@ -1,5 +1,4 @@
 export interface Like {
-  id: number;
   product: Product;
   createdAt?: Date | null;
 }

--- a/backend/likes/domains/repositories/LikesRepository.ts
+++ b/backend/likes/domains/repositories/LikesRepository.ts
@@ -2,6 +2,6 @@ import { Like } from '../entities/Likes';
 
 export interface LikesRepository {
   insert(userId: string, productId: number): Promise<number>;
-  delete(id: number): Promise<number>;
+  delete(productId: number, userId: string): Promise<number>;
   findById(userId: string): Promise<Like[]>;
 }

--- a/backend/likes/repositories/PrLikesRepository.ts
+++ b/backend/likes/repositories/PrLikesRepository.ts
@@ -12,24 +12,24 @@ export class PrLikesRepository implements LikesRepository {
         },
       });
 
-      return result.id;
+      return result.productId;
     } catch {
       throw new Error('=====LIKE_INSERT_ERROR=====');
     }
   }
 
-  async delete(id: number): Promise<number> {
+  async delete(productId: number, userId: string): Promise<number> {
     try {
       const result = await prisma.productLike.delete({
         where: {
-          id: id,
+          userId_productId: { userId, productId },
         },
         select: {
-          id: true,
+          productId: true,
         },
       });
 
-      return result.id;
+      return result.productId;
     } catch {
       throw new Error('=====LIKE_INSERT_ERROR=====');
     }
@@ -42,7 +42,6 @@ export class PrLikesRepository implements LikesRepository {
           userId: userId,
         },
         select: {
-          id: true,
           createdAt: true,
           product: {
             select: {

--- a/components/products/BrandInfo/brandInfo.module.scss
+++ b/components/products/BrandInfo/brandInfo.module.scss
@@ -2,6 +2,7 @@
   padding: 20px 16px;
   display: flex;
   width: 100%;
+  position: relative;
 
   & .brand_logo_wrap {
     border-radius: 50%;
@@ -16,4 +17,32 @@
   background: #fff;
   border: none;
   cursor: pointer;
+}
+
+.toast_contianer {
+  display: flex;
+  justify-content: center;
+  margin-left: none;
+  width: 100%;
+
+  & > div {
+    font-size: 1.4rem;
+  }
+}
+
+.toast_content {
+  max-width: 90%;
+}
+
+.toast_move_button {
+  display: flex;
+  width: 100%;
+  justify-content: center;
+  font-size: 1.4rem;
+  text-decoration: underline;
+  padding-right: 10px;
+}
+
+.font_size {
+  font-size: 1.4rem;
 }

--- a/components/products/BrandInfo/brandInfo.module.scss
+++ b/components/products/BrandInfo/brandInfo.module.scss
@@ -18,31 +18,3 @@
   border: none;
   cursor: pointer;
 }
-
-.toast_contianer {
-  display: flex;
-  justify-content: center;
-  margin-left: none;
-  width: 100%;
-
-  & > div {
-    font-size: 1.4rem;
-  }
-}
-
-.toast_content {
-  max-width: 90%;
-}
-
-.toast_move_button {
-  display: flex;
-  width: 100%;
-  justify-content: center;
-  font-size: 1.4rem;
-  text-decoration: underline;
-  padding-right: 10px;
-}
-
-.font_size {
-  font-size: 1.4rem;
-}

--- a/components/products/BrandInfo/index.tsx
+++ b/components/products/BrandInfo/index.tsx
@@ -12,6 +12,10 @@ import { useCallback, useEffect, useState } from 'react';
 import { likeService } from '@/services/like';
 import { IBrandLikeList } from '@/types/like';
 import { useLikeStore } from '@/store/likeStore';
+import Snackbar from '@mui/material/Snackbar';
+import Link from 'next/link';
+import SnackbarContent from '@mui/material/SnackbarContent';
+import Slide from '@mui/material/Slide';
 
 interface IProps {
   brandData?: IBrand;
@@ -21,6 +25,7 @@ const BrandInfo = ({ brandData }: IProps) => {
   const { addBrandLike, getBrandLikes, deleteBrandLike } = likeService;
   const [brandLikeList, setBrandLikeList] = useState<IBrandLikeList[]>([]);
   const [likedCheck, setLikedCheck] = useState(false);
+  const [toastOpen, setToastOpen] = useState(false);
 
   const { productDetailBrandLike, setProductDetailBrandLike } = useLikeStore();
 
@@ -71,8 +76,9 @@ const BrandInfo = ({ brandData }: IProps) => {
           .then((res) => {
             if (res.status === 200) {
               handleGetBrandLikes();
-              alert('잘 담겼어요!');
+
               setProductDetailBrandLike(productDetailBrandLike + 1);
+              setToastOpen(true);
             }
           })
           .catch((error) => {
@@ -123,6 +129,25 @@ const BrandInfo = ({ brandData }: IProps) => {
       <button className={styles.brand_like_button} onClick={() => handleAddBrandLike(brandData?.id ?? 0)}>
         <Image src={likedCheck ? onBookMark : bookmark} alt="좋아요" width={22} height={22} />
       </button>
+
+      <Snackbar
+        className={styles.toast_contianer}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+        open={toastOpen}
+        onClose={() => setToastOpen(false)}
+        slots={{ transition: Slide }}
+        // autoHideDuration={3000}
+      >
+        <SnackbarContent
+          className={styles.toast_content}
+          message="관심 브랜드에 저장되었습니다."
+          action={
+            <Link className={styles.toast_move_button} href={'/saved'}>
+              보러가기
+            </Link>
+          }
+        />
+      </Snackbar>
     </article>
   );
 };

--- a/components/products/BrandInfo/index.tsx
+++ b/components/products/BrandInfo/index.tsx
@@ -12,10 +12,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { likeService } from '@/services/like';
 import { IBrandLikeList } from '@/types/like';
 import { useLikeStore } from '@/store/likeStore';
-import Snackbar from '@mui/material/Snackbar';
-import Link from 'next/link';
-import SnackbarContent from '@mui/material/SnackbarContent';
-import Slide from '@mui/material/Slide';
+import LikeToast from '../LikeToast';
 
 interface IProps {
   brandData?: IBrand;
@@ -23,11 +20,10 @@ interface IProps {
 
 const BrandInfo = ({ brandData }: IProps) => {
   const { addBrandLike, getBrandLikes, deleteBrandLike } = likeService;
-  const [brandLikeList, setBrandLikeList] = useState<IBrandLikeList[]>([]);
   const [likedCheck, setLikedCheck] = useState(false);
   const [toastOpen, setToastOpen] = useState(false);
 
-  const { productDetailBrandLike, setProductDetailBrandLike } = useLikeStore();
+  const { productDetailBrandLike: storeLike, setProductDetailBrandLike: setStoreLike } = useLikeStore();
 
   const handleGetBrandLikes = useCallback(() => {
     getBrandLikes()
@@ -35,14 +31,19 @@ const BrandInfo = ({ brandData }: IProps) => {
         if (res.status === 200) {
           const checked = res.result.some((item: IBrandLikeList) => item?.brand?.id === brandData?.id);
 
-          setBrandLikeList(res.result);
           setLikedCheck(checked);
+
+          const findCount: IBrandLikeList = res.result.find(
+            (item: IBrandLikeList) => item?.brand?.id === brandData?.id
+          );
+
+          setStoreLike(findCount?.brand?._count?.brandLike ?? 0, checked);
         }
       })
       .catch((error) => {
         console.log('error', error.message);
       });
-  }, [brandData?.id, getBrandLikes]);
+  }, [brandData, getBrandLikes, setStoreLike]);
 
   const initLikeBrand = useCallback(() => {
     handleGetBrandLikes();
@@ -54,31 +55,28 @@ const BrandInfo = ({ brandData }: IProps) => {
         .then((res) => {
           if (res.status === 200) {
             alert('취소완료!');
-            initLikeBrand();
-            setProductDetailBrandLike(productDetailBrandLike - 1);
+            setStoreLike(storeLike.count - 1, false);
+            setLikedCheck(!likedCheck);
           }
         })
         .catch((error) => {
           console.log('error', error.message);
         });
     },
-    [deleteBrandLike, initLikeBrand, productDetailBrandLike, setProductDetailBrandLike]
+    [deleteBrandLike, setStoreLike, storeLike.count, likedCheck]
   );
 
   const handleAddBrandLike = useCallback(
     (id: number) => {
       if (likedCheck) {
-        const deleteId = brandLikeList?.find((item) => item?.brand?.id === id)?.id ?? 0;
-
-        handleDeleteBrandLike(deleteId);
+        handleDeleteBrandLike(id);
       } else {
         addBrandLike(id)
           .then((res) => {
             if (res.status === 200) {
-              handleGetBrandLikes();
-
-              setProductDetailBrandLike(productDetailBrandLike + 1);
+              setStoreLike(storeLike.count + 1, true);
               setToastOpen(true);
+              setLikedCheck(!likedCheck);
             }
           })
           .catch((error) => {
@@ -86,24 +84,12 @@ const BrandInfo = ({ brandData }: IProps) => {
           });
       }
     },
-    [
-      addBrandLike,
-      brandLikeList,
-      handleDeleteBrandLike,
-      handleGetBrandLikes,
-      likedCheck,
-      productDetailBrandLike,
-      setProductDetailBrandLike,
-    ]
+    [addBrandLike, handleDeleteBrandLike, likedCheck, storeLike, setStoreLike]
   );
 
   useEffect(() => {
     initLikeBrand();
   }, [initLikeBrand]);
-
-  useEffect(() => {
-    setProductDetailBrandLike(brandData?._count?.brandLike ?? 0);
-  }, [brandData?._count?.brandLike, setProductDetailBrandLike]);
 
   return (
     <article className={styles.brand_wrap}>
@@ -121,33 +107,21 @@ const BrandInfo = ({ brandData }: IProps) => {
             {brandData?.engName}
           </Text>
           <Text size={1.2} color="gray2">
-            {brandData?.korName} ㆍ 관심 {productDetailBrandLike}
+            {brandData?.korName} ㆍ 관심 {storeLike.count}
           </Text>
         </Flex>
       </Flex>
 
       <button className={styles.brand_like_button} onClick={() => handleAddBrandLike(brandData?.id ?? 0)}>
-        <Image src={likedCheck ? onBookMark : bookmark} alt="좋아요" width={22} height={22} />
+        <Image src={storeLike?.status ? onBookMark : bookmark} alt="좋아요" width={22} height={22} />
       </button>
 
-      <Snackbar
-        className={styles.toast_contianer}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      <LikeToast
         open={toastOpen}
-        onClose={() => setToastOpen(false)}
-        slots={{ transition: Slide }}
-        // autoHideDuration={3000}
-      >
-        <SnackbarContent
-          className={styles.toast_content}
-          message="관심 브랜드에 저장되었습니다."
-          action={
-            <Link className={styles.toast_move_button} href={'/saved'}>
-              보러가기
-            </Link>
-          }
-        />
-      </Snackbar>
+        setOpen={() => setToastOpen(false)}
+        message="관심 브랜드에 저장되었습니다."
+        link="/saved?tab=brand"
+      />
     </article>
   );
 };

--- a/components/products/LikeToast/index.tsx
+++ b/components/products/LikeToast/index.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import Snackbar from '@mui/material/Snackbar';
+import styles from './likeToast.module.scss';
+import SnackbarContent from '@mui/material/SnackbarContent';
+import Link from 'next/link';
+import Slide from '@mui/material/Slide';
+
+interface IProps {
+  open: boolean;
+  setOpen: () => void;
+  message: string;
+  link: string;
+}
+
+const LikeToast = ({ open, setOpen, message, link }: IProps) => {
+  return (
+    <Snackbar
+      className={styles.toast_container}
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      open={open}
+      onClose={setOpen}
+      slots={{ transition: Slide }}
+      autoHideDuration={3000}
+    >
+      <SnackbarContent
+        className={styles.toast_content}
+        message={message}
+        action={
+          <Link className={styles.toast_move_button} href={link}>
+            보러가기
+          </Link>
+        }
+      />
+    </Snackbar>
+  );
+};
+
+export default LikeToast;

--- a/components/products/LikeToast/likeToast.module.scss
+++ b/components/products/LikeToast/likeToast.module.scss
@@ -1,0 +1,27 @@
+.toast_container {
+  display: flex;
+  justify-content: center;
+  margin-left: none;
+  width: 100%;
+
+  & > div {
+    font-size: 1.4rem;
+  }
+}
+
+.toast_content {
+  max-width: 90%;
+}
+
+.toast_move_button {
+  display: flex;
+  width: 100%;
+  justify-content: center;
+  font-size: 1.4rem;
+  text-decoration: underline;
+  padding-right: 10px;
+}
+
+.font_size {
+  font-size: 1.4rem;
+}

--- a/components/saved/BrandSave/index.tsx
+++ b/components/saved/BrandSave/index.tsx
@@ -34,7 +34,13 @@ const BrandSave = ({ brandLikeData, onClickBookMark }: IProps) => {
           </Text>
           <Flex direction="column" gap={20}>
             {brandLikeData?.map((item) => (
-              <Flex key={item?.id} className={styles.save_item} tag="article" direction="column" gap={20}>
+              <Flex
+                key={'brand_saved_' + item?.brand?.id}
+                className={styles.save_item}
+                tag="article"
+                direction="column"
+                gap={20}
+              >
                 <Flex justify="between" align="center">
                   <Flex gap={16} align="center">
                     <span className={styles.logo_image}>
@@ -54,7 +60,7 @@ const BrandSave = ({ brandLikeData, onClickBookMark }: IProps) => {
                       </Text>
                     </Flex>
                   </Flex>
-                  <button className={styles.book_mark_button} onClick={() => onClickBookMark(item?.id)}>
+                  <button className={styles.book_mark_button} onClick={() => onClickBookMark(item?.brand?.id)}>
                     <Image src={BookMarkOn} alt="좋아요 아이콘" width={20} height={20} />
                   </button>
                 </Flex>

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -282,19 +282,17 @@ model SubCategory {
 }
 
 model ProductLike {
-  id            Int            @id @default(autoincrement())
   userId        String         @map("user_id") @db.Uuid
   productId     Int            @map("product_id")
   createdAt     DateTime?      @default(now()) @map("created_at") @db.Timestamptz(6)
   product       Product        @relation(fields: [productId], references: [id])
   user          User           @relation(fields: [userId], references: [id])
 
-
+  @@id([userId, productId])
   @@map("product_likes")
 }
 
 model BrandLike {
-  id            Int            @id @default(autoincrement())
   userId        String         @map("user_id") @db.Uuid
   brandId       Int            @map("brand_id")
   createdAt     DateTime?      @default(now()) @map("created_at") @db.Timestamptz(6)
@@ -302,6 +300,7 @@ model BrandLike {
   user          User           @relation(fields: [userId], references: [id])
   brand         Brand          @relation(fields: [brandId], references: [id])
 
+  @@id([userId, brandId])
   @@map("brand_likes")
 
 }

--- a/services/like/index.ts
+++ b/services/like/index.ts
@@ -9,8 +9,8 @@ export const likeService = {
     return data;
   },
 
-  deleteLike: async (id: number) => {
-    const { data, error } = await requester.delete(`api/likes`, { data: { id: id } }).catch((error) => error);
+  deleteLike: async (productId: number) => {
+    const { data, error } = await requester.delete(`api/likes`, { data: { id: productId } }).catch((error) => error);
 
     if (error) throw new Error(error.message);
 

--- a/store/likeStore.ts
+++ b/store/likeStore.ts
@@ -1,17 +1,19 @@
 import { create } from 'zustand';
 
 interface LikeStore {
-  productDetailLike: number;
-  productDetailBrandLike: number;
+  productDetailLike: { count: number; status: boolean };
+  productDetailBrandLike: { count: number; status: boolean };
 
-  setProductDetailLike: (num: number) => void;
-  setProductDetailBrandLike: (num: number) => void;
+  setProductDetailLike: (num: number, status: boolean) => void;
+  setProductDetailBrandLike: (num: number, status: boolean) => void;
 }
 
 export const useLikeStore = create<LikeStore>((set) => ({
-  productDetailLike: 0,
-  productDetailBrandLike: 0,
+  productDetailLike: { count: 0, status: false },
+  productDetailBrandLike: { count: 0, status: false },
 
-  setProductDetailLike: (count) => set({ productDetailLike: count }),
-  setProductDetailBrandLike: (count) => set({ productDetailBrandLike: count }),
+  setProductDetailLike: (count, status) => {
+    set({ productDetailLike: { count: count, status: status } });
+  },
+  setProductDetailBrandLike: (count, status) => set({ productDetailBrandLike: { count: count, status: status } }),
 }));

--- a/types/like.ts
+++ b/types/like.ts
@@ -17,7 +17,6 @@ export interface IBrandList {
 }
 
 export interface IBrandLikeList {
-  id: number;
   brand: Brand;
 }
 


### PR DESCRIPTION
## ❓ 관련 이슈 :

---

## 🛠 작업 내용

- 상세페이지에서 상품, 브랜드 좋아요 누르면 이동할수 있는 toast 추가
- saved 페이지 쿼리스트링 처리 
- productLikes, brandLikes id -> userId or brandId 로 복합키 변경 

## 🙌 체크사항

- [x] any 나 unknown 타입 사용을 지양 하셨나요 ?
- [x] 약속한 코드 컨벤션이나 폴더구조를 잘 지키셨나요 ?
- [x] npm package가 추가됬나요 ?
- [ ] env에 추가할 내용이 있나요 ?

## 🚀 기타 사항 (참고 자료, 화면 캡쳐 첨부 등)

-

---

##### 🙋‍♀️ build, lint가 무사히 성공했다면 팀원에게 PR 작성했다고 알려주세요!
