### PR TITLE
[refactor] 상품상세 메타태그, 페이지 로딩, 없는 상품 접근시 페이지 추가

### DIFF
--- a/app/(user)/LayoutWrapper.tsx
+++ b/app/(user)/LayoutWrapper.tsx
@@ -4,12 +4,13 @@ import { usePathname } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React, { useState, useEffect } from 'react';
-
+import styles from './mainPage.module.scss';
 import Header from '@/components/common/Header';
 import Footer from '@/components/common/Footer';
 import PaymentHeader from '@/components/Payments/PaymentHeader';
 import { useUserStore } from '@/store/userStore';
-import { BuyingHeader } from '@/components/my/BuyingHeader';
+import Image from 'next/image';
+import Loading from '@/public/images/loading.gif';
 
 interface IProps {
   children: React.ReactNode;
@@ -107,7 +108,11 @@ export default function LayoutWrapper({ children }: IProps) {
 
   // 하이드레이션 완료 전까지는 로딩 표시
   if (!mounted) {
-    return <div>Loading...</div>;
+    return (
+      <div className={styles.loading_container}>
+        <Image src={Loading} alt="loading" width={100} height={100} />
+      </div>
+    );
   }
 
   if (paymentsHeaderPaths) {

--- a/app/(user)/LayoutWrapper.tsx
+++ b/app/(user)/LayoutWrapper.tsx
@@ -10,7 +10,6 @@ import Footer from '@/components/common/Footer';
 import PaymentHeader from '@/components/Payments/PaymentHeader';
 import { useUserStore } from '@/store/userStore';
 import { BuyingHeader } from '@/components/my/BuyingHeader';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 interface IProps {
   children: React.ReactNode;
@@ -46,33 +45,19 @@ export default function LayoutWrapper({ children }: IProps) {
   }, [session, status, fetchUserData]);
 
   // 헤더만 숨길 경로들
-  const hideHeaderPaths = [
-    '/login',
-    '/find-email',
-    '/find-password',
-    '/my/address',
-    '/saved',
-    '/payments/checkout',
-  ];
+  const hideHeaderPaths = ['/login', '/find-email', '/find-password', '/my/address', '/saved', '/payments/checkout'];
 
   // 푸터만 숨길 경로들
-  const hideFooterPaths = ['/products', '/cart', '/payments','/signup',];
+  const hideFooterPaths = ['/products', '/cart', '/payments', '/signup'];
 
   // 헤더와 푸터 모두 숨길 경로들
-  const hideAllLayoutPaths = [
-    '/login',
-    '/my/buying',
-    '/find-email',
-    '/find-password',
-    '/my/buying',
-    '/my/order',
-  ];
+  const hideAllLayoutPaths = ['/login', '/my/buying', '/find-email', '/find-password', '/my/buying', '/my/order'];
 
   // nav와 검색버튼을을 숨김
-  const hideHeaderElementsPaths = ['/my', '/cart', '/saved','/signup',];
+  const hideHeaderElementsPaths = ['/my', '/cart', '/saved', '/signup'];
 
   // 로고를 숨기고고 뒤로가기 버튼
-  const showBackButtonPaths = ['/cart', '/my/profile', '/my/address', '/products/','/signup'];
+  const showBackButtonPaths = ['/cart', '/my/profile', '/my/address', '/products/', '/signup'];
 
   // 홈 버튼을 보여줄 경로들
   const showHomeButtonPaths = ['/cart'];
@@ -149,7 +134,7 @@ export default function LayoutWrapper({ children }: IProps) {
       )}
       {children}
       {!shouldHideFooter && <Footer />}
-      <ReactQueryDevtools initialIsOpen={false} />
+      {/* <ReactQueryDevtools initialIsOpen={false} /> */}
     </QueryClientProvider>
   );
 }

--- a/app/(user)/layout.tsx
+++ b/app/(user)/layout.tsx
@@ -21,7 +21,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={pretendard.variable}>
+    <html lang="ko" className={pretendard.variable}>
       <body suppressHydrationWarning={true}>
         <SessionProvider>
           <LayoutWrapper>{children}</LayoutWrapper>

--- a/app/(user)/layout.tsx
+++ b/app/(user)/layout.tsx
@@ -1,18 +1,18 @@
-import type { Metadata } from "next";
-import "@/styles/global.scss";
-import LayoutWrapper from "@/app/(user)/LayoutWrapper";
+import type { Metadata } from 'next';
+import '@/styles/global.scss';
+import LayoutWrapper from '@/app/(user)/LayoutWrapper';
 import SessionProvider from '@/components/providers/SessionProvider';
-import localFont from "next/font/local";
+import localFont from 'next/font/local';
 
 const pretendard = localFont({
-  src: "../../public/fonts/PretendardVariable.woff2",
-  display: "swap",
-  variable: "--font-pretendard",
+  src: '../../public/fonts/PretendardVariable.woff2',
+  display: 'swap',
+  variable: '--font-pretendard',
 });
 
 export const metadata: Metadata = {
-  title: "KNACK",
-  description: "KNACK",
+  title: 'KNACK',
+  description: 'KNACK에서 다양한 상품을 확인해보세요.',
 };
 
 export default function RootLayout({
@@ -24,9 +24,7 @@ export default function RootLayout({
     <html lang="en" className={pretendard.variable}>
       <body suppressHydrationWarning={true}>
         <SessionProvider>
-          <LayoutWrapper>
-            {children}
-          </LayoutWrapper>
+          <LayoutWrapper>{children}</LayoutWrapper>
         </SessionProvider>
       </body>
     </html>

--- a/app/(user)/mainPage.module.scss
+++ b/app/(user)/mainPage.module.scss
@@ -1,3 +1,12 @@
 .home_container {
   padding-bottom: 120px;
 }
+
+.loading_container {
+  max-width: 440px;
+  width: 100%;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/app/(user)/not-found.tsx
+++ b/app/(user)/not-found.tsx
@@ -1,6 +1,8 @@
 import Text from '@/components/common/Text';
 import Flex from '@/components/common/Flex';
 import WebAssetOffSharpIcon from '@mui/icons-material/WebAssetOffSharp';
+import Link from 'next/link';
+import Button from '@/components/common/Button';
 
 export default function NotFound() {
   return (
@@ -9,9 +11,13 @@ export default function NotFound() {
       <Text tag="h2" size={1.8} color="black1" weight={700} paddingTop={20}>
         페이지를 찾을 수 없습니다.
       </Text>
-      <Text tag="p" size={1.4} color="gray5" paddingTop={20}>
+      <Text tag="p" size={1.4} color="gray5" paddingTop={20} paddingBottom={20}>
         올바르지 않은 경로입니다. 다시 시도해주세요.
       </Text>
+
+      <Link href="/">
+        <Button>홈으로 돌아가기</Button>
+      </Link>
     </Flex>
   );
 }

--- a/app/(user)/payments/success/SuccessPage.module.scss
+++ b/app/(user)/payments/success/SuccessPage.module.scss
@@ -192,8 +192,6 @@
 }
 
 .image_wrap {
-  left: 50%;
-  transform: translateX(185%);
   background: #f4f4f4;
   justify-content: center;
   align-items: center;

--- a/app/(user)/payments/success/page.tsx
+++ b/app/(user)/payments/success/page.tsx
@@ -11,6 +11,7 @@ import Image from 'next/image';
 import { STORAGE_PATHS } from '@/constraint/auth';
 import { IAddress } from '@/types/address';
 import Text from '@/components/common/Text';
+import Flex from '@/components/common/Flex';
 
 export default function PaymentSuccess() {
   const params = useSearchParams();
@@ -249,20 +250,22 @@ export default function PaymentSuccess() {
 
   return (
     <div className={styles.sheet}>
-      <h2 className={styles.title}>구매가 완료되었습니다.</h2>
-      <p className={styles.subtitle}>주문 즉시 출고를 준비하여 안전하게 배송 될 예정입니다.</p>
+      <Flex direction="column" align="center" justify="center">
+        <h2 className={styles.title}>구매가 완료되었습니다.</h2>
+        <p className={styles.subtitle}>주문 즉시 출고를 준비하여 안전하게 배송 될 예정입니다.</p>
 
-      <div className={styles.image_wrap}>
-        {repProd?.thumbnailImage && (
-          <Image
-            src={`${STORAGE_PATHS.PRODUCT.THUMBNAIL}/${repProd.thumbnailImage}`}
-            alt={repProd.name}
-            width={80}
-            height={80}
-            className={styles.productImage}
-          />
-        )}
-      </div>
+        <div className={styles.image_wrap}>
+          {repProd?.thumbnailImage && (
+            <Image
+              src={`${STORAGE_PATHS.PRODUCT.THUMBNAIL}/${repProd.thumbnailImage}`}
+              alt={repProd.name}
+              width={80}
+              height={80}
+              className={styles.productImage}
+            />
+          )}
+        </div>
+      </Flex>
 
       <button className={styles.primary_btn} onClick={() => router.push(`/my/order/${paymentNumber}`)}>
         구매 내역 상세보기

--- a/app/(user)/products/[id]/page.tsx
+++ b/app/(user)/products/[id]/page.tsx
@@ -12,6 +12,7 @@ import AdditionalBenefits from '@/components/products/AdditionalBenefits';
 import { IProduct } from '@/types/productDetail';
 
 import BottomFixButton from '@/components/products/BottomFixButton';
+import { Metadata } from 'next';
 
 interface IProps {
   params: Promise<{
@@ -19,7 +20,28 @@ interface IProps {
   }>;
 }
 
+export async function generateMetadata({ params }: IProps): Promise<Metadata> {
+  const { id } = await params;
 
+  try {
+    const { getProduct } = productsService;
+    const productData: IProduct = await getProduct(Number(id)).then((res) => {
+      return res.result;
+    });
+
+    return {
+      title: `${productData.korName} | KNACK`,
+      description: `${productData.engName} - ${productData.korName} | KNACK`,
+    };
+  } catch (error) {
+    console.error('상품 메타데이터 조회 실패:', error);
+
+    return {
+      title: 'Product | KNACK',
+      description: 'KNACK에서 다양한 상품을 확인해보세요.',
+    };
+  }
+}
 
 const ProductDetail = async ({ params }: IProps) => {
   const { id } = await params;

--- a/app/(user)/products/[id]/page.tsx
+++ b/app/(user)/products/[id]/page.tsx
@@ -10,9 +10,9 @@ import TextReview from '@/components/products/TextReview';
 import { productsService } from '@/services/products';
 import AdditionalBenefits from '@/components/products/AdditionalBenefits';
 import { IProduct } from '@/types/productDetail';
-
 import BottomFixButton from '@/components/products/BottomFixButton';
 import { Metadata } from 'next';
+import { notFound } from 'next/navigation';
 
 interface IProps {
   params: Promise<{
@@ -53,7 +53,7 @@ const ProductDetail = async ({ params }: IProps) => {
   });
 
   if (!productData) {
-    return <div>존재하지 않는 상품 입니다.</div>;
+    return notFound();
   }
 
   return (

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,17 @@
+import Text from '@/components/common/Text';
+import Flex from '@/components/common/Flex';
+import WebAssetOffSharpIcon from '@mui/icons-material/WebAssetOffSharp';
+
+export default function NotFound() {
+  return (
+    <Flex paddingHorizontal={20} paddingVertical={100} direction="column" justify="center" align="center">
+      <WebAssetOffSharpIcon sx={{ fontSize: 100, color: '#333' }} />
+      <Text tag="h2" size={1.8} color="black1" weight={700} paddingTop={20}>
+        페이지를 찾을 수 없습니다.
+      </Text>
+      <Text tag="p" size={1.4} color="gray5" paddingTop={20}>
+        올바르지 않은 경로입니다. 다시 시도해주세요.
+      </Text>
+    </Flex>
+  );
+}

--- a/components/my/BuyList/buyList.module.scss
+++ b/components/my/BuyList/buyList.module.scss
@@ -16,4 +16,5 @@
   border: none;
   background: none;
   cursor: pointer;
+  color: $black;
 }


### PR DESCRIPTION
## ❓ 관련 이슈 :

---

## 🛠 작업 내용

- 상품 상세페이지 상품명으로 메타태그 생성하도록 로직 추가
- 없는 상품 페이지 접근 시 not found 페이지 추가
- 리액트쿼리 devtools 주석
- 아이폰 기본 스타일 대응 마이페이지 배송상태 버튼 color 추가 
- 결제완료 페이지 스타일 수정
 ***

## 🙌 체크사항

- [x] any 나 unknown 타입 사용을 지양 하셨나요 ?
- [x] 약속한 코드 컨벤션이나 폴더구조를 잘 지키셨나요 ?
- [ ] npm package가 추가됬나요 ?
- [ ] env에 추가할 내용이 있나요 ?

## 🚀 기타 사항 (참고 자료, 화면 캡쳐 첨부 등)

-

---

##### 🙋‍♀️ build, lint가 무사히 성공했다면 팀원에게 PR 작성했다고 알려주세요!
