### PR TITLE
[fix] 상품목록 바텀시트 선택 리스트 초기화 이슈 해결

### DIFF
--- a/components/common/BottomSheet/index.tsx
+++ b/components/common/BottomSheet/index.tsx
@@ -115,32 +115,33 @@ export default function BottomSheet({
             dragConstraints={{ top: 0 }}
             dragElastic={0.1}
             onDragEnd={handleDragEnd}
-            dragMomentum={false}
           >
-            {showHandle && (
-              <div className={styles.handle} onPointerDown={(e) => dragControls.start(e)}>
-                <div className={styles.handle_bar} />
-              </div>
-            )}
+            <section onPointerDown={(e) => dragControls.start(e)}>
+              {showHandle && (
+                <div className={styles.handle}>
+                  <div className={styles.handle_bar} />
+                </div>
+              )}
 
-            {title && (
-              <div className={styles.header}>
-                <Flex justify="center" paddingVertical={16}>
-                  <Text tag="h2" size={1.8} weight={600}>
-                    {title}
-                  </Text>
-                </Flex>
-                {isCloseButton && (
-                  <button className={styles.close_button} onClick={onClose} aria-label="닫기">
-                    <Image src={closeLarge} alt="닫기" width={24} height={24} />
-                  </button>
-                )}
-              </div>
-            )}
+              {title && (
+                <div className={styles.header}>
+                  <Flex justify="center" paddingVertical={16}>
+                    <Text tag="h2" size={1.8} weight={600}>
+                      {title}
+                    </Text>
+                  </Flex>
+                  {isCloseButton && (
+                    <button className={styles.close_button} onClick={onClose} aria-label="닫기">
+                      <Image src={closeLarge} alt="닫기" width={24} height={24} />
+                    </button>
+                  )}
+                </div>
+              )}
+            </section>
 
-            <div className={styles.content} style={style}>
+            <section className={styles.content} style={style}>
               {children}
-            </div>
+            </section>
           </motion.div>
         </div>
       )}

--- a/hooks/search/useSearchBottomSheetInit.ts
+++ b/hooks/search/useSearchBottomSheetInit.ts
@@ -41,10 +41,10 @@ export const useSearchBottomSheetInit = ({
     }
 
     setIsDataReady(hasCategories && hasBrands && hasSizes);
-  }, [categories, brands, sizes, initialBrands.length]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [categories, sizes]);
 
   // filterQuery와 데이터가 준비되었을 때 selectedBottomList 초기화
-  // 브랜드 검색 시에는 인한 브랜드 목록 변경 x
   useEffect(() => {
     if (!isDataReady || !isOpen || initialBrands.length === 0) return;
 


### PR DESCRIPTION
## ❓ 관련 이슈 :

---

## 🛠 작업 내용

- 바텀시트 핸들 슬라이드 가능한 영역이 너무 좁은 것 같아서 타이틀 있을 경우 타이틀 영역까지 확장
- 상품목록 바텀시트 브랜드 검색 시 간헐적으로 선택 리스트가 초기화 되는 이슈 해결
- ***

## 🙌 체크사항

- [x] any 나 unknown 타입 사용을 지양 하셨나요 ?
- [x] 약속한 코드 컨벤션이나 폴더구조를 잘 지키셨나요 ?
- [ ] npm package가 추가됬나요 ?
- [ ] env에 추가할 내용이 있나요 ?

## 🚀 기타 사항 (참고 자료, 화면 캡쳐 첨부 등)

-

---

##### 🙋‍♀️ build, lint가 무사히 성공했다면 팀원에게 PR 작성했다고 알려주세요!
